### PR TITLE
Fix vectorized list_snell functions and is_not_forward_angle

### DIFF
--- a/tmm_fast/tmm_fast_torch.py
+++ b/tmm_fast/tmm_fast_torch.py
@@ -240,8 +240,17 @@ def list_snell_vec(n_list, th):
     # The first and last entry need to be the forward angle (the intermediate
     # layers don't matter, see https://arxiv.org/abs/1603.02720 Section 5)
 
-    angles[:, 0] = -is_not_forward_angle(n_list[0], angles[:, 0]) * pi + angles[:, 0]
-    angles[:, -1] = -is_not_forward_angle(n_list[-1], angles[:, -1]) * pi + angles[:, -1]
+    angles[:, 0] = torch.where(
+        is_not_forward_angle(n_list[0], angles[:, 0]).bool(),
+        pi - angles[:, 0],
+        angles[:, 0],
+    )
+    angles[:, -1] = torch.where(
+        is_not_forward_angle(n_list[-1], angles[:, -1]).bool(),
+        pi - angles[:, -1],
+        angles[:, -1],
+    )
+
     return angles
 
 def interface_r_vec(polarization, n_i, n_f, th_i, th_f):


### PR DESCRIPTION
I believe this fixes #23.

Fix the vectorized list_snell functions to properly match the original tmm function

Correct is_not_forward_angle in vectorized_tmm_dispersive_multistack.py to match the version in tmm_fast_torch.py

The lines:
```
answer[torch.where(~(ncostheta.imag > 100 * EPSILON))] = ncostheta.real[torch.where(~(ncostheta.imag > 100 * EPSILON))] > 0
answer[torch.where(~(ncostheta.imag > 100 * EPSILON))] = ncostheta.real[torch.where(~(ncostheta.imag > 100 * EPSILON))] > 0
```
were missing the appropriate `abs` calls, so negative imag parts were not being flagged in the `answer` tensor. I decided to copy over the correct corresponding code in `tmm_fast_torch.py` instead of fixing this confusing use of `torch.where`.

Fix the typos that added `~`'s.